### PR TITLE
Restrict the usage of SHA-1

### DIFF
--- a/README
+++ b/README
@@ -52,18 +52,19 @@ $ make install
 An initial set of the most common TSS "./configure" options are defined
 to enable/disable different features.
 
---disable-tpm-2.0 - include only TPM 1.2 support
---disable-tpm-1.2 - include only TPM 2.0 support
---disable-hwtpm   - don't use the hardware TPM, use a software one instead
---disable-rmtpm   - when using a hardware TPM, don't use the resource manager
---enable-noprint  - build a TSS library without tracing or prints
---enable-nofile   - build a TSS library that does not use files to preserve state
-		    (dependency on --disable-tpm-1.2)
-		    The utilities (not the TSS library) require file support.
---enable-nocrypto - build a TSS library that does not require a crypto library
-		    (dependency on "--enable-nofile")
---enable-noecc    - build a TSS library that does not require OpenSSL elliptic curve support
---enable-debug    - build a TSS library used for debugging.
+--disable-tpm-2.0         - include only TPM 1.2 support
+--disable-tpm-1.2         - include only TPM 2.0 support
+--disable-hwtpm           - don't use the hardware TPM, use a software one instead
+--disable-rmtpm        	  - when using a hardware TPM, don't use the resource manager
+--enable-noprint          - build a TSS library without tracing or prints
+--enable-nofile           - build a TSS library that does not use files to preserve state
+			    (dependency on --disable-tpm-1.2)
+		            The utilities (not the TSS library) require file support.
+--enable-nocrypto      	  - build a TSS library that does not require a crypto library
+			    (dependency on "--enable-nofile")
+--enable-noecc            - build a TSS library that does not require OpenSSL elliptic curve support
+--enable-debug            - build a TSS library used for debugging.
+--enable-nodeprecatedalgs - build a TSS library without SHA-1 support
 
 Example 2: To configure the TSS library to use the hardware TPM, build and
 install the package in the default /usr/local directories requires root

--- a/configure.ac
+++ b/configure.ac
@@ -123,6 +123,11 @@ AC_ARG_ENABLE(rmtpm,
    AM_CONDITIONAL([CONFIG_RMTPM], [test "x$enable_rmtpm" = "xyes"])
    AS_IF([test "$enable_rmtpm" != "yes"], [enable_rmtpm="no"])
 
+AC_ARG_ENABLE(nodeprecatedalgs,
+   AS_HELP_STRING([--enable-nodeprecatedalgs], [Restrict usage of SHA-1]))
+   AM_CONDITIONAL([CONFIG_TSS_NODEPRECATEDALGS], [test "x$enable_nodeprecatedalgs" = "xyes"])
+   AS_IF([test "$enable_nodeprecatedalgs" != "yes"], [enable_nodeprecatedalgs="no"])
+
 AC_CONFIG_FILES([Makefile
 		utils/Makefile
 		utils12/Makefile
@@ -131,12 +136,13 @@ AC_OUTPUT
 
 # Give some feedback
 echo   "Configuration:"
-echo   "	CFLAGS:		$CFLAGS"
-echo   "	tpm12:		$tpm12"
-echo   "	tpm20:		$tpm20"
-echo   "	hwtpm:		$enable_hwtpm"
-echo   "	rmtpm:		$enable_rmtpm"
-echo   "	nofile:		$enable_nofile"
-echo   "	noprint:	$enable_noprint"
-echo   "	nocrypto:	$enable_nocrypto"
-echo   "	noecc:		$enable_noecc"
+echo   "	CFLAGS:			$CFLAGS"
+echo   "	tpm12:			$tpm12"
+echo   "	tpm20:			$tpm20"
+echo   "	hwtpm:			$enable_hwtpm"
+echo   "	rmtpm:			$enable_rmtpm"
+echo   "	nofile:			$enable_nofile"
+echo   "	noprint:		$enable_noprint"
+echo   "	nocrypto:		$enable_nocrypto"
+echo   "	noecc:			$enable_noecc"
+echo   "	nodeprecatedalgs:	$enable_nodeprecatedalgs"

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -60,6 +60,10 @@ if CONFIG_TSS_NOECC
 libibmtss_la_CFLAGS += -DTPM_TSS_NOECC
 endif
 
+if CONFIG_TSS_NODEPRECATEDALGS
+libibmtss_la_CFLAGS += -DTPM_TSS_NODEPRECATEDALGS
+endif
+
 libibmtss_la_CCFLAGS = -Wall -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wformat=2 -Wold-style-definition -Wno-self-assign -ggdb
 libibmtss_la_LDFLAGS = -version-info @TSSLIB_VERSION_INFO@
 
@@ -76,6 +80,10 @@ endif
 
 if CONFIG_TSS_NOECC
 libibmtssutils_la_CFLAGS += -DTPM_TSS_NOECC
+endif
+
+if CONFIG_TSS_NODEPRECATEDALGS
+libibmtssutils_la_CFLAGS += -DTPM_TSS_NODEPRECATEDALGS
 endif
 
 #current[:revision[:age]]
@@ -120,8 +128,14 @@ if !CONFIG_TSS_NOFILE
 bin_PROGRAMS += timepacket
 endif
 
+UTILS_CFLAGS =
+
 if CONFIG_TSS_NOECC
-UTILS_CFLAGS = -DTPM_TSS_NOECC
+UTILS_CFLAGS += -DTPM_TSS_NOECC
+endif
+
+if CONFIG_TSS_NODEPRECATEDALGS
+UTILS_CFLAGS += -DTPM_TSS_NODEPRECATEDALGS
 endif
 
 activatecredential_SOURCES = activatecredential.c

--- a/utils/certify.c
+++ b/utils/certify.c
@@ -407,5 +407,7 @@ static void printUsage(void)
     printf("\t01\tcontinue\n");
     printf("\t20\tcommand decrypt\n");
     printf("\t40\tresponse encrypt\n");
+    printf("\n");
+    printf("Depending on the build configuration, some hash algorithms may not be available.\n");
     exit(1);	
 }

--- a/utils/certifycreation.c
+++ b/utils/certifycreation.c
@@ -449,5 +449,7 @@ static void printUsage(void)
     printf("\t01\tcontinue\n");
     printf("\t20\tcommand decrypt\n");
     printf("\t40\tresponse encrypt\n");
+    printf("\n");
+    printf("Depending on the build configuration, some hash algorithms may not be available.\n");
     exit(1);	
 }

--- a/utils/create.c
+++ b/utils/create.c
@@ -710,5 +710,7 @@ static void printUsage(void)
     printf("\t01\tcontinue\n");
     printf("\t20\tcommand decrypt\n");
     printf("\t40\tresponse encrypt\n");
+    printf("\n");
+    printf("Depending on the build configuration, some hash algorithms may not be available.\n");
     exit(1);	
 }

--- a/utils/createloaded.c
+++ b/utils/createloaded.c
@@ -628,5 +628,7 @@ static void printUsage(void)
     printf("\t01\tcontinue\n");
     printf("\t20\tcommand decrypt\n");
     printf("\t40\tresponse encrypt\n");
+    printf("\n");
+    printf("Depending on the build configuration, some hash algorithms may not be available.\n");
     exit(1);	
 }

--- a/utils/createprimary.c
+++ b/utils/createprimary.c
@@ -801,5 +801,7 @@ static void printUsage(void)
     printf("\t01\tcontinue\n");
     printf("\t20\tcommand decrypt\n");
     printf("\t40\tresponse encrypt\n");
+    printf("\n");
+    printf("Depending on the build configuration, some hash algorithms may not be available.\n");
     exit(1);	
 }

--- a/utils/cryptoutils.c
+++ b/utils/cryptoutils.c
@@ -2313,9 +2313,11 @@ TPM_RC signRSAFromRSA(uint8_t *signature, size_t *signatureLength,
     /* map the hash algorithm to the openssl NID */
     if (rc == 0) {
 	switch (hashAlg) {
+#ifndef TPM_TSS_NODEPRECATEDALGS
 	  case TPM_ALG_SHA1:
 	    nid = NID_sha1;
 	    break;
+#endif
 	  case TPM_ALG_SHA256:
 	    nid = NID_sha256;
 	    break;
@@ -2427,10 +2429,12 @@ TPM_RC verifyRSASignatureFromRSA(unsigned char *message,
     /* map from hash algorithm to openssl nid */
     if (rc == 0) {
 	switch (halg) {
+#ifndef TPM_TSS_NODEPRECATEDALGS
 	  case TPM_ALG_SHA1:
 	    nid = NID_sha1;
 	    md = EVP_sha1();
 	    break;
+#endif
 	  case TPM_ALG_SHA256:
 	    nid = NID_sha256;
 	    md = EVP_sha256();

--- a/utils/getcommandauditdigest.c
+++ b/utils/getcommandauditdigest.c
@@ -391,5 +391,7 @@ static void printUsage(void)
     printf("\t01\tcontinue\n");
     printf("\t20\tcommand decrypt\n");
     printf("\t40\tresponse encrypt\n");
+    printf("\n");
+    printf("Depending on the build configuration, some hash algorithms may not be available.\n");
     exit(1);	
 }

--- a/utils/getsessionauditdigest.c
+++ b/utils/getsessionauditdigest.c
@@ -387,5 +387,7 @@ static void printUsage(void)
     printf("\t01\tcontinue\n");
     printf("\t20\tcommand decrypt\n");
     printf("\t40\tresponse encrypt\n");
+    printf("\n");
+    printf("Depending on the build configuration, some hash algorithms may not be available.\n");
     exit(1);	
 }

--- a/utils/gettime.c
+++ b/utils/gettime.c
@@ -391,5 +391,7 @@ static void printUsage(void)
     printf("\t01\tcontinue\n");
     printf("\t20\tcommand decrypt\n");
     printf("\t40\tresponse encrypt\n");
+    printf("\n");
+    printf("Depending on the build configuration, some hash algorithms may not be available.\n");
     exit(1);	
 }

--- a/utils/hash.c
+++ b/utils/hash.c
@@ -306,5 +306,7 @@ static void printUsage(void)
     printf("\t[-ns\tno space, no text, no newlines]\n");
     printf("\t[-oh\thash file name (default do not save)]\n");
     printf("\t[-tk\tticket file name (default do not save)]\n");
+    printf("\n");
+    printf("Depending on the build configuration, some hash algorithms may not be available.\n");
     exit(1);	
 }

--- a/utils/hashsequencestart.c
+++ b/utils/hashsequencestart.c
@@ -249,5 +249,7 @@ static void printUsage(void)
     printf("\t-se[0-2] session handle / attributes (default NULL)\n");
     printf("\t01\tcontinue\n");
     printf("\t20\tcommand decrypt\n");
+    printf("\n");
+    printf("Depending on the build configuration, some hash algorithms may not be available.\n");
     exit(1);	
 }

--- a/utils/hmac.c
+++ b/utils/hmac.c
@@ -352,5 +352,7 @@ static void printUsage(void)
     printf("\t01\tcontinue\n");
     printf("\t20\tcommand decrypt\n");
     printf("\t40\tresponse encrypt\n");
+    printf("\n");
+    printf("Depending on the build configuration, some hash algorithms may not be available.\n");
     exit(1);	
 }

--- a/utils/hmacstart.c
+++ b/utils/hmacstart.c
@@ -274,5 +274,7 @@ static void printUsage(void)
     printf("\n");
     printf("\t-se[0-2] session handle / attributes (default PWAP)\n");
     printf("\t01\tcontinue\n");
+    printf("\n");
+    printf("Depending on the build configuration, some hash algorithms may not be available.\n");
     exit(1);	
 }

--- a/utils/importpem.c
+++ b/utils/importpem.c
@@ -486,5 +486,7 @@ static void printUsage(void)
     printf("\t01\tcontinue\n");
     printf("\t20\tcommand decrypt\n");
     printf("\t40\tresponse encrypt\n");
+    printf("\n");
+    printf("Depending on the build configuration, some hash algorithms may not be available.\n");
     exit(1);	
 }

--- a/utils/loadexternal.c
+++ b/utils/loadexternal.c
@@ -538,5 +538,7 @@ static void printUsage(void)
     printf("\t20\tcommand decrypt\n");
     printf("\t40\tresponse encrypt\n");
     printf("\t80\taudit\n");
+    printf("\n");
+    printf("Depending on the build configuration, some hash algorithms may not be available.\n");
     exit(1);	
 }

--- a/utils/man/man1/tsscertify.1
+++ b/utils/man/man1/tsscertify.1
@@ -44,3 +44,5 @@ command decrypt
 .TP
 40
 response encrypt
+.PP
+Depending on the build configuration, some hash algorithms may not be available.

--- a/utils/man/man1/tsscertifycreation.1
+++ b/utils/man/man1/tsscertifycreation.1
@@ -47,3 +47,5 @@ command decrypt
 .TP
 40
 response encrypt
+.PP
+Depending on the build configuration, some hash algorithms may not be available.

--- a/utils/man/man1/tsscreate.1
+++ b/utils/man/man1/tsscreate.1
@@ -125,3 +125,5 @@ command decrypt
 .TP
 40
 response encrypt
+.PP
+Depending on the build configuration, some hash algorithms may not be available.

--- a/utils/man/man1/tsscreateloaded.1
+++ b/utils/man/man1/tsscreateloaded.1
@@ -126,3 +126,5 @@ command decrypt
 .TP
 40
 response encrypt
+.PP
+Depending on the build configuration, some hash algorithms may not be available.

--- a/utils/man/man1/tsscreateprimary.1
+++ b/utils/man/man1/tsscreateprimary.1
@@ -129,3 +129,5 @@ command decrypt
 .TP
 40
 response encrypt
+.PP
+Depending on the build configuration, some hash algorithms may not be available.

--- a/utils/man/man1/tssgetcommandauditdigest.1
+++ b/utils/man/man1/tssgetcommandauditdigest.1
@@ -41,3 +41,5 @@ command decrypt
 .TP
 40
 response encrypt
+.PP
+Depending on the build configuration, some hash algorithms may not be available.

--- a/utils/man/man1/tssgetsessionauditdigest.1
+++ b/utils/man/man1/tssgetsessionauditdigest.1
@@ -44,3 +44,5 @@ command decrypt
 .TP
 40
 response encrypt
+.PP
+Depending on the build configuration, some hash algorithms may not be available.

--- a/utils/man/man1/tssgettime.1
+++ b/utils/man/man1/tssgettime.1
@@ -41,3 +41,5 @@ command decrypt
 .TP
 40
 response encrypt
+.PP
+Depending on the build configuration, some hash algorithms may not be available.

--- a/utils/man/man1/tsshash.1
+++ b/utils/man/man1/tsshash.1
@@ -28,3 +28,5 @@ hash file name (default do not save)]
 .TP
 [\-tk
 ticket file name (default do not save)]
+.PP
+Depending on the build configuration, some hash algorithms may not be available.

--- a/utils/man/man1/tsshashsequencestart.1
+++ b/utils/man/man1/tsshashsequencestart.1
@@ -21,3 +21,5 @@ continue
 .TP
 20
 command decrypt
+.PP
+Depending on the build configuration, some hash algorithms may not be available.

--- a/utils/man/man1/tsshmac.1
+++ b/utils/man/man1/tsshmac.1
@@ -35,3 +35,5 @@ command decrypt
 .TP
 40
 response encrypt
+.PP
+Depending on the build configuration, some hash algorithms may not be available.

--- a/utils/man/man1/tsshmacstart.1
+++ b/utils/man/man1/tsshmacstart.1
@@ -23,3 +23,5 @@ password for sequence (default empty)
 .TP
 01
 continue
+.PP
+Depending on the build configuration, some hash algorithms may not be available.

--- a/utils/man/man1/tssimportpem.1
+++ b/utils/man/man1/tssimportpem.1
@@ -67,3 +67,5 @@ command decrypt
 .TP
 40
 response encrypt
+.PP
+Depending on the build configuration, some hash algorithms may not be available.

--- a/utils/man/man1/tssloadexternal.1
+++ b/utils/man/man1/tssloadexternal.1
@@ -71,3 +71,5 @@ response encrypt
 .TP
 80
 audit
+.PP
+Depending on the build configuration, some hash algorithms may not be available.

--- a/utils/man/man1/tssnvcertify.1
+++ b/utils/man/man1/tssnvcertify.1
@@ -50,3 +50,5 @@ command decrypt
 .TP
 40
 response encrypt
+.PP
+Depending on the build configuration, some hash algorithms may not be available.

--- a/utils/man/man1/tssnvdefinespace.1
+++ b/utils/man/man1/tssnvdefinespace.1
@@ -99,3 +99,5 @@ continue
 .TP
 20
 command decrypt
+.PP
+Depending on the build configuration, some hash algorithms may not be available.

--- a/utils/man/man1/tsspolicysigned.1
+++ b/utils/man/man1/tsspolicysigned.1
@@ -44,3 +44,5 @@ ticket file name]
 .TP
 [\-to
 timeout file name]
+.PP
+Depending on the build configuration, some hash algorithms may not be available.

--- a/utils/man/man1/tssquote.1
+++ b/utils/man/man1/tssquote.1
@@ -44,3 +44,5 @@ command decrypt
 .TP
 40
 response encrypt
+.PP
+Depending on the build configuration, some hash algorithms may not be available.

--- a/utils/man/man1/tssrsadecrypt.1
+++ b/utils/man/man1/tssrsadecrypt.1
@@ -31,3 +31,5 @@ command decrypt
 .TP
 40
 response encrypt
+.PP
+Depending on the build configuration, some hash algorithms may not be available.

--- a/utils/man/man1/tsssetcommandcodeauditstatus.1
+++ b/utils/man/man1/tsssetcommandcodeauditstatus.1
@@ -29,3 +29,5 @@ continue
 .TP
 20
 command decrypt
+.PP
+Depending on the build configuration, some hash algorithms may not be available.

--- a/utils/man/man1/tsssetprimarypolicy.1
+++ b/utils/man/man1/tsssetprimarypolicy.1
@@ -26,3 +26,5 @@ continue
 .TP
 20
 command decrypt
+.PP
+Depending on the build configuration, some hash algorithms may not be available.

--- a/utils/man/man1/tsssign.1
+++ b/utils/man/man1/tsssign.1
@@ -46,3 +46,5 @@ continue
 .TP
 20
 command decrypt
+.PP
+Depending on the build configuration, some hash algorithms may not be available.

--- a/utils/man/man1/tssstartauthsession.1
+++ b/utils/man/man1/tssstartauthsession.1
@@ -35,3 +35,5 @@ bind password for bind handle (default empty)]
 .TP
 [\-on
 nonceTPM file for policy session (default do not save)]
+.PP
+Depending on the build configuration, some hash algorithms may not be available.

--- a/utils/man/man1/tssverifysignature.1
+++ b/utils/man/man1/tssverifysignature.1
@@ -57,3 +57,5 @@ command decrypt
 .TP
 80
 audit
+.PP
+Depending on the build configuration, some hash algorithms may not be available.

--- a/utils/nvcertify.c
+++ b/utils/nvcertify.c
@@ -445,5 +445,7 @@ static void printUsage(void)
     printf("\t01\tcontinue\n");
     printf("\t20\tcommand decrypt\n");
     printf("\t40\tresponse encrypt\n");
+    printf("\n");
+    printf("Depending on the build configuration, some hash algorithms may not be available.\n");
     exit(1);	
 }

--- a/utils/nvdefinespace.c
+++ b/utils/nvdefinespace.c
@@ -590,5 +590,7 @@ static void printUsage(void)
     printf("\t-se[0-2] session handle / attributes (default PWAP)\n");
     printf("\t01\tcontinue\n");
     printf("\t20\tcommand decrypt\n");
+    printf("\n");
+    printf("Depending on the build configuration, some hash algorithms may not be available.\n");
     exit(1);	
 }

--- a/utils/policysigned.c
+++ b/utils/policysigned.c
@@ -452,5 +452,7 @@ static void printUsage(void)
     printf("\t[-pwdk\tsigning key password (default null)]\n");
     printf("\t[-tk\tticket file name]\n");
     printf("\t[-to\ttimeout file name]\n");
+    printf("\n");
+    printf("Depending on the build configuration, some hash algorithms may not be available.\n");
     exit(1);	
 }

--- a/utils/quote.c
+++ b/utils/quote.c
@@ -435,5 +435,7 @@ static void printUsage(void)
     printf("\t01\tcontinue\n");
     printf("\t20\tcommand decrypt\n");
     printf("\t40\tresponse encrypt\n");
+    printf("\n");
+    printf("Depending on the build configuration, some hash algorithms may not be available.\n");
     exit(1);	
 }

--- a/utils/reg.sh
+++ b/utils/reg.sh
@@ -69,12 +69,20 @@ PREFIX=./
 
 #PREFIX="valgrind ./"
 
-# hash algorithms to be used for testing
-
-export ITERATE_ALGS="sha1 sha256 sha384 sha512"
-export ITERATE_ALGS_SIZES="20 32 48 64"
-export ITERATE_ALGS_COUNT=4
-export BAD_ITERATE_ALGS="sha256 sha384 sha512 sha1"
+# Hash algorithms to be used for testing. Uncomment or set shell env variable to restrict.
+# export TPM_TSS_NODEPRECATEDALGS=1
+if [ "${TPM_TSS_NODEPRECATEDALGS}" ]; then
+	export ITERATE_ALGS="sha256 sha384 sha512"
+	export ITERATE_ALGS_SIZES="32 48 64"
+	export ITERATE_ALGS_COUNT=3
+	export BAD_ITERATE_ALGS="sha384 sha512 sha256"
+else
+	export ITERATE_ALGS="sha1 sha256 sha384 sha512"
+	export ITERATE_ALGS_SIZES="20 32 48 64"
+	export ITERATE_ALGS_COUNT=4
+	export BAD_ITERATE_ALGS="sha256 sha384 sha512 sha1"
+fi
+export ITERATE_ALGS_WITH_SHA1="sha1 sha256 sha384 sha512"
 export CURVE_ALGS="bnp256 nistp256 nistp384"
 
 # When going to the TPM device, don't use the resource manager

--- a/utils/regtests/testattest.sh
+++ b/utils/regtests/testattest.sh
@@ -381,9 +381,8 @@ echo ""
 
 for HALG in ${ITERATE_ALGS}
 do
-
     echo "Start an audit session ${HALG}"
-    ${PREFIX}startauthsession -se h -halg  ${HALG} > run.out
+    ${PREFIX}startauthsession -se h -halg ${HALG} > run.out
     checkSuccess $?
 
     echo "PCR 16 reset"

--- a/utils/regtests/testevent.sh
+++ b/utils/regtests/testevent.sh
@@ -67,7 +67,7 @@ echo ""
 
 for TYPE in "1" "2"
 do
-    for HALG in ${ITERATE_ALGS}
+    for HALG in ${ITERATE_ALGS_WITH_SHA1}
     do
 
 	echo "Power cycle to reset IMA PCR"

--- a/utils/rsadecrypt.c
+++ b/utils/rsadecrypt.c
@@ -512,5 +512,7 @@ static void printUsage(void)
     printf("\t01\tcontinue\n");
     printf("\t20\tcommand decrypt\n");
     printf("\t40\tresponse encrypt\n");
+    printf("\n");
+    printf("Depending on the build configuration, some hash algorithms may not be available.\n");
     exit(1);	
 }

--- a/utils/setcommandcodeauditstatus.c
+++ b/utils/setcommandcodeauditstatus.c
@@ -294,5 +294,7 @@ static void printUsage(void)
     printf("\t-se[0-2] session handle / attributes (default PWAP)\n");
     printf("\t01\tcontinue\n");
     printf("\t20\tcommand decrypt\n");
+    printf("\n");
+    printf("Depending on the build configuration, some hash algorithms may not be available.\n");
     exit(1);	
 }

--- a/utils/setprimarypolicy.c
+++ b/utils/setprimarypolicy.c
@@ -296,5 +296,7 @@ static void printUsage(void)
     printf("\t-se[0-2] session handle / attributes (default PWAP)\n");
     printf("\t01\tcontinue\n");
     printf("\t20\tcommand decrypt\n");
+    printf("\n");
+    printf("Depending on the build configuration, some hash algorithms may not be available.\n");
     exit(1);	
 }

--- a/utils/sign.c
+++ b/utils/sign.c
@@ -487,5 +487,7 @@ static void printUsage(void)
     printf("\t-se[0-2] session handle / attributes (default PWAP)\n");
     printf("\t01\tcontinue\n");
     printf("\t20\tcommand decrypt\n");
+    printf("\n");
+    printf("Depending on the build configuration, some hash algorithms may not be available.\n");
     exit(1);	
 }

--- a/utils/startauthsession.c
+++ b/utils/startauthsession.c
@@ -297,5 +297,7 @@ static void printUsage(void)
     printf("\t[-pwdb\tbind password for bind handle (default empty)]\n");
     printf("\t[-sym\t(xor, aes) symmetric parameter encryption algorithm (default xor)]\n");
     printf("\t[-on\tnonceTPM file for policy session (default do not save)]\n");
+    printf("\n");
+    printf("Depending on the build configuration, some hash algorithms may not be available.\n");
     exit(1);	
 }

--- a/utils/tss20.c
+++ b/utils/tss20.c
@@ -112,6 +112,7 @@ struct TSS_HMAC_CONTEXT {
 
 /* functions for command pre- and post- processing */
 
+typedef TPM_RC (*TSS_CheckParametersFunction_t)(COMMAND_PARAMETERS *in);
 typedef TPM_RC (*TSS_PreProcessFunction_t)(TSS_CONTEXT *tssContext,
 					   COMMAND_PARAMETERS *in,
 					   EXTRA_PARAMETERS *extra);
@@ -238,11 +239,404 @@ static TPM_RC TSS_PO_NV_ReadLock(TSS_CONTEXT *tssContext,
 				 void *out,
 				 void *extra);
 
+/*
+  Functions to check for usage of deprecated algorithms.
+*/
+
+static TPM_RC TSS_CheckSha1_PublicArea(TPMT_PUBLIC *publicArea)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	if (publicArea->nameAlg == TPM_ALG_SHA1) {
+	    rc = TSS_RC_BAD_HASH_ALGORITHM;
+	}
+    }
+
+    if (rc == 0) {
+	if (((publicArea->type == TPM_ALG_RSA) || (publicArea->type == TPM_ALG_ECC)) &&
+	    (publicArea->parameters.asymDetail.scheme.scheme != TPM_ALG_NULL) &&
+	    (publicArea->parameters.asymDetail.scheme.details.anySig.hashAlg == TPM_ALG_SHA1)) {
+	    rc = TSS_RC_BAD_HASH_ALGORITHM;
+	}
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CheckSha1_SigScheme(TPMT_SIG_SCHEME *sigScheme)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	if (sigScheme->details.any.hashAlg == TPM_ALG_SHA1) {
+	    rc = TSS_RC_BAD_HASH_ALGORITHM;
+	}
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_StartAuthSession(StartAuthSession_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	if (in->authHash == TPM_ALG_SHA1) {
+	    rc = TSS_RC_BAD_HASH_ALGORITHM;
+	}
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_Create(Create_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	rc = TSS_CheckSha1_PublicArea(&in->inPublic.publicArea);
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_Load(Load_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	rc = TSS_CheckSha1_PublicArea(&in->inPublic.publicArea);
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_LoadExternal(LoadExternal_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	rc = TSS_CheckSha1_PublicArea(&in->inPublic.publicArea);
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_CreateLoaded(CreateLoaded_In *in)
+{
+    TPM_RC rc = 0;
+    uint32_t size = sizeof(in->inPublic.t.buffer);
+    uint8_t *buffer = in->inPublic.t.buffer;
+    TPMT_PUBLIC publicArea;
+
+    if (rc == 0) {
+	rc = TSS_TPMT_PUBLIC_Unmarshalu(&publicArea, &buffer, &size, TRUE);
+    }
+
+    if (rc == 0) {
+	rc = TSS_CheckSha1_PublicArea(&publicArea);
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_Import(Import_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	rc = TSS_CheckSha1_PublicArea(&in->objectPublic.publicArea);
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_RSA_Encrypt(RSA_Encrypt_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	if (in->inScheme.details.anySig.hashAlg == TPM_ALG_SHA1) {
+	    rc = TSS_RC_BAD_HASH_ALGORITHM;
+	}
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_RSA_Decrypt(RSA_Decrypt_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	if (in->inScheme.details.anySig.hashAlg == TPM_ALG_SHA1) {
+	    rc = TSS_RC_BAD_HASH_ALGORITHM;
+	}
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_ECC_Encrypt(ECC_Encrypt_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	if (in->inScheme.details.mgf1.hashAlg == TPM_ALG_SHA1) {
+	    rc = TSS_RC_BAD_HASH_ALGORITHM;
+	}
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_ECC_Decrypt(ECC_Decrypt_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	if (in->inScheme.details.mgf1.hashAlg == TPM_ALG_SHA1) {
+	    rc = TSS_RC_BAD_HASH_ALGORITHM;
+	}
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_Hash(Hash_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	if (in->hashAlg == TPM_ALG_SHA1) {
+	    rc = TSS_RC_BAD_HASH_ALGORITHM;
+	}
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_HMAC(HMAC_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	if (in->hashAlg == TPM_ALG_SHA1) {
+	    rc = TSS_RC_BAD_HASH_ALGORITHM;
+	}
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_HMAC_Start(HMAC_Start_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	if (in->hashAlg == TPM_ALG_SHA1) {
+	    rc = TSS_RC_BAD_HASH_ALGORITHM;
+	}
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_HashSequenceStart(HashSequenceStart_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	if (in->hashAlg == TPM_ALG_SHA1) {
+	    rc = TSS_RC_BAD_HASH_ALGORITHM;
+	}
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_Certify(Certify_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	rc = TSS_CheckSha1_SigScheme(&in->inScheme);
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_CertifyX509(CertifyX509_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	rc = TSS_CheckSha1_SigScheme(&in->inScheme);
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_CertifyCreation(CertifyCreation_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	rc = TSS_CheckSha1_SigScheme(&in->inScheme);
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_Quote(Quote_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	rc = TSS_CheckSha1_SigScheme(&in->inScheme);
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_GetSessionAuditDigest(GetSessionAuditDigest_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	rc = TSS_CheckSha1_SigScheme(&in->inScheme);
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_GetCommandAuditDigest(GetCommandAuditDigest_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	rc = TSS_CheckSha1_SigScheme(&in->inScheme);
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_GetTime(GetTime_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	rc = TSS_CheckSha1_SigScheme(&in->inScheme);
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_VerifySignature(VerifySignature_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	if (in->signature.signature.any.hashAlg == TPM_ALG_SHA1) {
+	    rc = TSS_RC_BAD_HASH_ALGORITHM;
+	}
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_Sign(Sign_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	rc = TSS_CheckSha1_SigScheme(&in->inScheme);
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_SetCommandCodeAuditStatus(SetCommandCodeAuditStatus_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	if (in->auditAlg == TPM_ALG_SHA1) {
+	    rc = TSS_RC_BAD_HASH_ALGORITHM;
+	}
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_PolicySigned(PolicySigned_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	if (in->auth.signature.any.hashAlg == TPM_ALG_SHA1) {
+	    rc = TSS_RC_BAD_HASH_ALGORITHM;
+	}
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_CreatePrimary(CreatePrimary_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	rc = TSS_CheckSha1_PublicArea(&in->inPublic.publicArea);
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_SetPrimaryPolicy(SetPrimaryPolicy_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	if (in->hashAlg == TPM_ALG_SHA1) {
+	    rc = TSS_RC_BAD_HASH_ALGORITHM;
+	}
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_NV_DefineSpace(NV_DefineSpace_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	if (in->publicInfo.nvPublic.nameAlg == TPM_ALG_SHA1) {
+	    rc = TSS_RC_BAD_HASH_ALGORITHM;
+	}
+    }
+
+    return rc;
+}
+
+static TPM_RC TSS_CH_NV_Certify(NV_Certify_In *in)
+{
+    TPM_RC rc = 0;
+
+    if (rc == 0) {
+	rc = TSS_CheckSha1_SigScheme(&in->inScheme);
+    }
+
+    return rc;
+}
+
 typedef struct TSS_TABLE {
-    TPM_CC 			commandCode;
-    TSS_PreProcessFunction_t	preProcessFunction;
-    TSS_ChangeAuthFunction_t	changeAuthFunction;
-    TSS_PostProcessFunction_t 	postProcessFunction;
+    TPM_CC 				commandCode;
+    TSS_CheckParametersFunction_t	checkParametersFunction;
+    TSS_PreProcessFunction_t		preProcessFunction;
+    TSS_ChangeAuthFunction_t		changeAuthFunction;
+    TSS_PostProcessFunction_t 		postProcessFunction;
 } TSS_TABLE;
 
 /* This table indexes from the command to pre- and post- processing functions.  A missing entry is
@@ -250,118 +644,118 @@ typedef struct TSS_TABLE {
 
 static const TSS_TABLE tssTable [] = {
 				 
-    {TPM_CC_Startup, NULL, NULL, NULL},
-    {TPM_CC_Shutdown, NULL, NULL, NULL},
-    {TPM_CC_SelfTest, NULL, NULL, NULL},
-    {TPM_CC_IncrementalSelfTest, NULL, NULL, NULL},
-    {TPM_CC_GetTestResult, NULL, NULL, NULL},
-    {TPM_CC_StartAuthSession, (TSS_PreProcessFunction_t)TSS_PR_StartAuthSession, NULL, (TSS_PostProcessFunction_t)TSS_PO_StartAuthSession},
-    {TPM_CC_PolicyRestart, NULL, NULL, NULL},
-    {TPM_CC_Create, NULL, NULL, NULL},
-    {TPM_CC_Load, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_Load},
-    {TPM_CC_LoadExternal, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_LoadExternal},
-    {TPM_CC_ReadPublic, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_ReadPublic},
-    {TPM_CC_ActivateCredential, NULL, NULL, NULL},
-    {TPM_CC_MakeCredential, NULL, NULL, NULL},
-    {TPM_CC_Unseal, NULL, NULL, NULL},
-    {TPM_CC_ObjectChangeAuth, NULL, NULL, NULL},
-    {TPM_CC_CreateLoaded, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_CreateLoaded},
-    {TPM_CC_Duplicate, NULL, NULL, NULL},
-    {TPM_CC_Rewrap, NULL, NULL, NULL},
-    {TPM_CC_Import, NULL, NULL, NULL},
-    {TPM_CC_RSA_Encrypt, NULL, NULL, NULL},
-    {TPM_CC_RSA_Decrypt, NULL, NULL, NULL},
-    {TPM_CC_ECDH_KeyGen, NULL, NULL, NULL},
-    {TPM_CC_ECDH_ZGen, NULL, NULL, NULL},
-    {TPM_CC_ECC_Encrypt, NULL, NULL, NULL},
-    {TPM_CC_ECC_Decrypt, NULL, NULL, NULL},
-    {TPM_CC_ECC_Parameters, NULL, NULL, NULL},
-    {TPM_CC_ZGen_2Phase, NULL, NULL, NULL},
-    {TPM_CC_EncryptDecrypt, NULL, NULL, NULL},
-    {TPM_CC_EncryptDecrypt2, NULL, NULL, NULL},
-    {TPM_CC_Hash, NULL, NULL, NULL},
-    {TPM_CC_HMAC, NULL, NULL, NULL},
-    {TPM_CC_GetRandom, NULL, NULL, NULL},
-    {TPM_CC_StirRandom, NULL, NULL, NULL},
-    {TPM_CC_HMAC_Start, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_HMAC_Start},
-    {TPM_CC_HashSequenceStart, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_HashSequenceStart},
-    {TPM_CC_SequenceUpdate, NULL, NULL, NULL},
-    {TPM_CC_SequenceComplete, NULL,NULL, (TSS_PostProcessFunction_t)TSS_PO_SequenceComplete},
-    {TPM_CC_EventSequenceComplete, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_EventSequenceComplete},
-    {TPM_CC_Certify, NULL, NULL, NULL},
-    {TPM_CC_CertifyX509, NULL, NULL, NULL},
-    {TPM_CC_CertifyCreation, NULL, NULL, NULL},
-    {TPM_CC_Quote, NULL, NULL, NULL},
-    {TPM_CC_GetSessionAuditDigest, NULL, NULL, NULL},
-    {TPM_CC_GetCommandAuditDigest, NULL, NULL, NULL},
-    {TPM_CC_GetTime, NULL, NULL, NULL},
-    {TPM_CC_Commit, NULL, NULL, NULL},
-    {TPM_CC_EC_Ephemeral, NULL, NULL, NULL},
-    {TPM_CC_VerifySignature, NULL, NULL, NULL},
-    {TPM_CC_Sign, NULL, NULL, NULL},
-    {TPM_CC_SetCommandCodeAuditStatus, NULL, NULL, NULL},
-    {TPM_CC_PCR_Extend, NULL, NULL, NULL},
-    {TPM_CC_PCR_Event, NULL, NULL, NULL},
-    {TPM_CC_PCR_Read, NULL, NULL, NULL},
-    {TPM_CC_PCR_Allocate, NULL, NULL, NULL},
-    {TPM_CC_PCR_SetAuthPolicy, NULL, NULL, NULL},
-    {TPM_CC_PCR_SetAuthValue, NULL, NULL, NULL},
-    {TPM_CC_PCR_Reset, NULL, NULL, NULL},
-    {TPM_CC_PolicySigned, NULL, NULL, NULL},
-    {TPM_CC_PolicySecret, NULL, NULL, NULL},
-    {TPM_CC_PolicyTicket, NULL, NULL, NULL},
-    {TPM_CC_PolicyOR, NULL, NULL, NULL},
-    {TPM_CC_PolicyPCR, NULL, NULL, NULL},
-    {TPM_CC_PolicyLocality, NULL, NULL, NULL},
-    {TPM_CC_PolicyNV, NULL, NULL, NULL},
-    {TPM_CC_PolicyAuthorizeNV, NULL, NULL, NULL},
-    {TPM_CC_PolicyCounterTimer, NULL, NULL, NULL},
-    {TPM_CC_PolicyCommandCode, NULL, NULL, NULL},
-    {TPM_CC_PolicyPhysicalPresence, NULL, NULL, NULL},
-    {TPM_CC_PolicyCpHash, NULL, NULL, NULL},
-    {TPM_CC_PolicyNameHash, NULL, NULL, NULL},
-    {TPM_CC_PolicyDuplicationSelect, NULL, NULL, NULL},
-    {TPM_CC_PolicyAuthorize, NULL, NULL, NULL},
-    {TPM_CC_PolicyAuthValue, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_PolicyAuthValue},
-    {TPM_CC_PolicyPassword, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_PolicyPassword},
-    {TPM_CC_PolicyGetDigest, NULL, NULL, NULL},
-    {TPM_CC_PolicyNvWritten, NULL, NULL, NULL},
-    {TPM_CC_PolicyTemplate, NULL, NULL, NULL},
-    {TPM_CC_CreatePrimary, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_CreatePrimary},
-    {TPM_CC_HierarchyControl, NULL, NULL, NULL},
-    {TPM_CC_SetPrimaryPolicy, NULL, NULL, NULL},
-    {TPM_CC_ChangePPS, NULL, NULL, NULL},
-    {TPM_CC_ChangeEPS, NULL, NULL, NULL},
-    {TPM_CC_Clear, NULL, NULL, NULL},
-    {TPM_CC_ClearControl, NULL, NULL, NULL},
-    {TPM_CC_HierarchyChangeAuth, NULL, (TSS_ChangeAuthFunction_t)TSS_CA_HierarchyChangeAuth, NULL},
-    {TPM_CC_DictionaryAttackLockReset, NULL, NULL, NULL},
-    {TPM_CC_DictionaryAttackParameters, NULL, NULL, NULL},
-    {TPM_CC_PP_Commands, NULL, NULL, NULL},
-    {TPM_CC_SetAlgorithmSet, NULL, NULL, NULL},
-    {TPM_CC_ContextSave, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_ContextSave},
-    {TPM_CC_ContextLoad, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_ContextLoad},
-    {TPM_CC_FlushContext, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_FlushContext},
-    {TPM_CC_EvictControl, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_EvictControl},
-    {TPM_CC_ReadClock, NULL, NULL, NULL},
-    {TPM_CC_ClockSet, NULL, NULL, NULL},
-    {TPM_CC_ClockRateAdjust, NULL, NULL, NULL},
-    {TPM_CC_GetCapability, NULL, NULL, NULL},
-    {TPM_CC_TestParms, NULL, NULL, NULL},
-    {TPM_CC_NV_DefineSpace, (TSS_PreProcessFunction_t)TSS_PR_NV_DefineSpace, NULL,  (TSS_PostProcessFunction_t)TSS_PO_NV_DefineSpace},
-    {TPM_CC_NV_UndefineSpace, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_NV_UndefineSpace},
-    {TPM_CC_NV_UndefineSpaceSpecial, NULL, (TSS_ChangeAuthFunction_t)TSS_CA_NV_UndefineSpaceSpecial, (TSS_PostProcessFunction_t)TSS_PO_NV_UndefineSpaceSpecial},
-    {TPM_CC_NV_ReadPublic, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_NV_ReadPublic},
-    {TPM_CC_NV_Write, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_NV_Write},
-    {TPM_CC_NV_Increment, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_NV_Write},
-    {TPM_CC_NV_Extend, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_NV_Write},
-    {TPM_CC_NV_SetBits, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_NV_Write},
-    {TPM_CC_NV_WriteLock, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_NV_WriteLock},
-    {TPM_CC_NV_GlobalWriteLock, NULL, NULL, NULL},
-    {TPM_CC_NV_Read, NULL, NULL, NULL},
-    {TPM_CC_NV_ReadLock, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_NV_ReadLock},
-    {TPM_CC_NV_ChangeAuth, NULL, (TSS_ChangeAuthFunction_t)TSS_CA_NV_ChangeAuth, NULL},
-    {TPM_CC_NV_Certify, NULL, NULL, NULL}
+    {TPM_CC_Startup, NULL, NULL, NULL, NULL},
+    {TPM_CC_Shutdown, NULL, NULL, NULL, NULL},
+    {TPM_CC_SelfTest, NULL, NULL, NULL, NULL},
+    {TPM_CC_IncrementalSelfTest, NULL, NULL, NULL, NULL},
+    {TPM_CC_GetTestResult, NULL, NULL, NULL, NULL},
+    {TPM_CC_StartAuthSession, (TSS_CheckParametersFunction_t)TSS_CH_StartAuthSession, (TSS_PreProcessFunction_t)TSS_PR_StartAuthSession, NULL, (TSS_PostProcessFunction_t)TSS_PO_StartAuthSession},
+    {TPM_CC_PolicyRestart, NULL, NULL, NULL, NULL},
+    {TPM_CC_Create, (TSS_CheckParametersFunction_t)TSS_CH_Create, NULL, NULL, NULL},
+    {TPM_CC_Load, (TSS_CheckParametersFunction_t)TSS_CH_Load, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_Load},
+    {TPM_CC_LoadExternal, (TSS_CheckParametersFunction_t)TSS_CH_LoadExternal, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_LoadExternal},
+    {TPM_CC_ReadPublic, NULL, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_ReadPublic},
+    {TPM_CC_ActivateCredential, NULL, NULL, NULL, NULL},
+    {TPM_CC_MakeCredential, NULL, NULL, NULL, NULL},
+    {TPM_CC_Unseal, NULL, NULL, NULL, NULL},
+    {TPM_CC_ObjectChangeAuth, NULL, NULL, NULL, NULL},
+    {TPM_CC_CreateLoaded, (TSS_CheckParametersFunction_t)TSS_CH_CreateLoaded, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_CreateLoaded},
+    {TPM_CC_Duplicate, NULL, NULL, NULL, NULL},
+    {TPM_CC_Rewrap, NULL, NULL, NULL, NULL},
+    {TPM_CC_Import, (TSS_CheckParametersFunction_t)TSS_CH_Import, NULL, NULL, NULL},
+    {TPM_CC_RSA_Encrypt, (TSS_CheckParametersFunction_t)TSS_CH_RSA_Encrypt, NULL, NULL, NULL},
+    {TPM_CC_RSA_Decrypt, (TSS_CheckParametersFunction_t)TSS_CH_RSA_Decrypt, NULL, NULL, NULL},
+    {TPM_CC_ECDH_KeyGen, NULL, NULL, NULL, NULL},
+    {TPM_CC_ECDH_ZGen, NULL, NULL, NULL, NULL},
+    {TPM_CC_ECC_Encrypt, (TSS_CheckParametersFunction_t)TSS_CH_ECC_Encrypt, NULL, NULL, NULL},
+    {TPM_CC_ECC_Decrypt, (TSS_CheckParametersFunction_t)TSS_CH_ECC_Decrypt, NULL, NULL, NULL},
+    {TPM_CC_ECC_Parameters, NULL, NULL, NULL, NULL},
+    {TPM_CC_ZGen_2Phase, NULL, NULL, NULL, NULL},
+    {TPM_CC_EncryptDecrypt, NULL, NULL, NULL, NULL},
+    {TPM_CC_EncryptDecrypt2, NULL, NULL, NULL, NULL},
+    {TPM_CC_Hash, (TSS_CheckParametersFunction_t)TSS_CH_Hash, NULL, NULL, NULL},
+    {TPM_CC_HMAC, (TSS_CheckParametersFunction_t)TSS_CH_HMAC, NULL, NULL, NULL},
+    {TPM_CC_GetRandom, NULL, NULL, NULL, NULL},
+    {TPM_CC_StirRandom, NULL, NULL, NULL, NULL},
+    {TPM_CC_HMAC_Start, (TSS_CheckParametersFunction_t)TSS_CH_HMAC_Start, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_HMAC_Start},
+    {TPM_CC_HashSequenceStart, (TSS_CheckParametersFunction_t)TSS_CH_HashSequenceStart, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_HashSequenceStart},
+    {TPM_CC_SequenceUpdate, NULL, NULL, NULL, NULL},
+    {TPM_CC_SequenceComplete, NULL, NULL,NULL, (TSS_PostProcessFunction_t)TSS_PO_SequenceComplete},
+    {TPM_CC_EventSequenceComplete, NULL, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_EventSequenceComplete},
+    {TPM_CC_Certify, (TSS_CheckParametersFunction_t)TSS_CH_Certify, NULL, NULL, NULL},
+    {TPM_CC_CertifyX509, (TSS_CheckParametersFunction_t)TSS_CH_CertifyX509, NULL, NULL, NULL},
+    {TPM_CC_CertifyCreation, (TSS_CheckParametersFunction_t)TSS_CH_CertifyCreation, NULL, NULL, NULL},
+    {TPM_CC_Quote, (TSS_CheckParametersFunction_t)TSS_CH_Quote, NULL, NULL, NULL},
+    {TPM_CC_GetSessionAuditDigest, (TSS_CheckParametersFunction_t)TSS_CH_GetSessionAuditDigest, NULL, NULL, NULL},
+    {TPM_CC_GetCommandAuditDigest, (TSS_CheckParametersFunction_t)TSS_CH_GetCommandAuditDigest, NULL, NULL, NULL},
+    {TPM_CC_GetTime, (TSS_CheckParametersFunction_t)TSS_CH_GetTime, NULL, NULL, NULL},
+    {TPM_CC_Commit, NULL, NULL, NULL, NULL},
+    {TPM_CC_EC_Ephemeral, NULL, NULL, NULL, NULL},
+    {TPM_CC_VerifySignature, (TSS_CheckParametersFunction_t)TSS_CH_VerifySignature, NULL, NULL, NULL},
+    {TPM_CC_Sign, (TSS_CheckParametersFunction_t)TSS_CH_Sign, NULL, NULL, NULL},
+    {TPM_CC_SetCommandCodeAuditStatus, (TSS_CheckParametersFunction_t)TSS_CH_SetCommandCodeAuditStatus, NULL, NULL, NULL},
+    {TPM_CC_PCR_Extend, NULL, NULL, NULL, NULL},
+    {TPM_CC_PCR_Event, NULL, NULL, NULL, NULL},
+    {TPM_CC_PCR_Read, NULL, NULL, NULL, NULL},
+    {TPM_CC_PCR_Allocate, NULL, NULL, NULL, NULL},
+    {TPM_CC_PCR_SetAuthPolicy, NULL, NULL, NULL, NULL},
+    {TPM_CC_PCR_SetAuthValue, NULL, NULL, NULL, NULL},
+    {TPM_CC_PCR_Reset, NULL, NULL, NULL, NULL},
+    {TPM_CC_PolicySigned, (TSS_CheckParametersFunction_t)TSS_CH_PolicySigned, NULL, NULL, NULL},
+    {TPM_CC_PolicySecret, NULL, NULL, NULL, NULL},
+    {TPM_CC_PolicyTicket, NULL, NULL, NULL, NULL},
+    {TPM_CC_PolicyOR, NULL, NULL, NULL, NULL},
+    {TPM_CC_PolicyPCR, NULL, NULL, NULL, NULL},
+    {TPM_CC_PolicyLocality, NULL, NULL, NULL, NULL},
+    {TPM_CC_PolicyNV, NULL, NULL, NULL, NULL},
+    {TPM_CC_PolicyAuthorizeNV, NULL, NULL, NULL, NULL},
+    {TPM_CC_PolicyCounterTimer, NULL, NULL, NULL, NULL},
+    {TPM_CC_PolicyCommandCode, NULL, NULL, NULL, NULL},
+    {TPM_CC_PolicyPhysicalPresence, NULL, NULL, NULL, NULL},
+    {TPM_CC_PolicyCpHash, NULL, NULL, NULL, NULL},
+    {TPM_CC_PolicyNameHash, NULL, NULL, NULL, NULL},
+    {TPM_CC_PolicyDuplicationSelect, NULL, NULL, NULL, NULL},
+    {TPM_CC_PolicyAuthorize, NULL, NULL, NULL, NULL},
+    {TPM_CC_PolicyAuthValue, NULL, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_PolicyAuthValue},
+    {TPM_CC_PolicyPassword, NULL, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_PolicyPassword},
+    {TPM_CC_PolicyGetDigest, NULL, NULL, NULL, NULL},
+    {TPM_CC_PolicyNvWritten, NULL, NULL, NULL, NULL},
+    {TPM_CC_PolicyTemplate, NULL, NULL, NULL, NULL},
+    {TPM_CC_CreatePrimary, (TSS_CheckParametersFunction_t)TSS_CH_CreatePrimary, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_CreatePrimary},
+    {TPM_CC_HierarchyControl, NULL, NULL, NULL, NULL},
+    {TPM_CC_SetPrimaryPolicy, (TSS_CheckParametersFunction_t)TSS_CH_SetPrimaryPolicy, NULL, NULL, NULL},
+    {TPM_CC_ChangePPS, NULL, NULL, NULL, NULL},
+    {TPM_CC_ChangeEPS, NULL, NULL, NULL, NULL},
+    {TPM_CC_Clear, NULL, NULL, NULL, NULL},
+    {TPM_CC_ClearControl, NULL, NULL, NULL, NULL},
+    {TPM_CC_HierarchyChangeAuth, NULL, NULL, (TSS_ChangeAuthFunction_t)TSS_CA_HierarchyChangeAuth, NULL},
+    {TPM_CC_DictionaryAttackLockReset, NULL, NULL, NULL, NULL},
+    {TPM_CC_DictionaryAttackParameters, NULL, NULL, NULL, NULL},
+    {TPM_CC_PP_Commands, NULL, NULL, NULL, NULL},
+    {TPM_CC_SetAlgorithmSet, NULL, NULL, NULL, NULL},
+    {TPM_CC_ContextSave, NULL, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_ContextSave},
+    {TPM_CC_ContextLoad, NULL, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_ContextLoad},
+    {TPM_CC_FlushContext, NULL, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_FlushContext},
+    {TPM_CC_EvictControl, NULL, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_EvictControl},
+    {TPM_CC_ReadClock, NULL, NULL, NULL, NULL},
+    {TPM_CC_ClockSet, NULL, NULL, NULL, NULL},
+    {TPM_CC_ClockRateAdjust, NULL, NULL, NULL, NULL},
+    {TPM_CC_GetCapability, NULL, NULL, NULL, NULL},
+    {TPM_CC_TestParms, NULL, NULL, NULL, NULL},
+    {TPM_CC_NV_DefineSpace, (TSS_CheckParametersFunction_t)TSS_CH_NV_DefineSpace, (TSS_PreProcessFunction_t)TSS_PR_NV_DefineSpace, NULL,  (TSS_PostProcessFunction_t)TSS_PO_NV_DefineSpace},
+    {TPM_CC_NV_UndefineSpace, NULL, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_NV_UndefineSpace},
+    {TPM_CC_NV_UndefineSpaceSpecial, NULL, NULL, (TSS_ChangeAuthFunction_t)TSS_CA_NV_UndefineSpaceSpecial, (TSS_PostProcessFunction_t)TSS_PO_NV_UndefineSpaceSpecial},
+    {TPM_CC_NV_ReadPublic, NULL, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_NV_ReadPublic},
+    {TPM_CC_NV_Write, NULL, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_NV_Write},
+    {TPM_CC_NV_Increment, NULL, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_NV_Write},
+    {TPM_CC_NV_Extend, NULL, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_NV_Write},
+    {TPM_CC_NV_SetBits, NULL, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_NV_Write},
+    {TPM_CC_NV_WriteLock, NULL, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_NV_WriteLock},
+    {TPM_CC_NV_GlobalWriteLock, NULL, NULL, NULL, NULL},
+    {TPM_CC_NV_Read, NULL, NULL, NULL, NULL},
+    {TPM_CC_NV_ReadLock, NULL, NULL, NULL, (TSS_PostProcessFunction_t)TSS_PO_NV_ReadLock},
+    {TPM_CC_NV_ChangeAuth, NULL, NULL, (TSS_ChangeAuthFunction_t)TSS_CA_NV_ChangeAuth, NULL},
+    {TPM_CC_NV_Certify, (TSS_CheckParametersFunction_t)TSS_CH_NV_Certify, NULL, NULL, NULL}
 };
 
 #ifndef TPM_TSS_NO_PRINT
@@ -650,6 +1044,10 @@ static TPM_RC TSS_Command_ChangeAuthProcessor(TSS_CONTEXT *tssContext,
 					      COMMAND_PARAMETERS *in);
 #endif	/* TPM_TSS_NOCRYPTO */
 
+#ifdef TPM_TSS_NODEPRECATEDALGS
+static TPM_RC TSS_Command_CheckParameters(TPM_CC commandCode,
+					  COMMAND_PARAMETERS *in);
+#endif
 static TPM_RC TSS_Command_PreProcessor(TSS_CONTEXT *tssContext,
 				       TPM_CC commandCode,
 				       COMMAND_PARAMETERS *in,
@@ -692,6 +1090,12 @@ TPM_RC TSS_Execute20(TSS_CONTEXT *tssContext,
 {
     TPM_RC		rc = 0;
 	
+#ifdef TPM_TSS_NODEPRECATEDALGS
+    if (rc == 0) {
+	rc = TSS_Command_CheckParameters(commandCode, in);
+    }
+#endif
+
     /* create a TSS authorization context */
     if (rc == 0) {
 	TSS_InitAuthContext(tssContext->tssAuthContext);
@@ -3758,6 +4162,38 @@ static TPM_RC TSS_CA_NV_UndefineSpaceSpecial(TSS_CONTEXT *tssContext,
 #endif	/* TPM_TSS_NOCRYPTO */
     return rc;
 }
+
+#ifdef TPM_TSS_NODEPRECATEDALGS
+static TPM_RC TSS_Command_CheckParameters(TPM_CC commandCode,
+					  COMMAND_PARAMETERS *in)
+{
+    TPM_RC 				rc = 0;
+    size_t 				index;
+    int 				found;
+    TSS_CheckParametersFunction_t	checkParametersFunction = NULL;
+
+    /* search the table for a check parameters function */
+    if (rc == 0) {
+	found = FALSE;
+	for (index = 0 ; (index < (sizeof(tssTable) / sizeof(TSS_TABLE))) && !found ; index++) {
+	    if (tssTable[index].commandCode == commandCode) {
+		found = TRUE;
+		break;	/* don't increment index if found */
+	    }
+	}
+    }
+    /* found false means there is no check parameters function.  This permits the table to be smaller
+       if desired. */
+    if ((rc == 0) && found) {
+	checkParametersFunction = tssTable[index].checkParametersFunction;
+	/* call the check parameters function if there is one */
+	if (checkParametersFunction != NULL) {
+	    rc = checkParametersFunction(in);
+	}
+    }
+    return rc;
+}
+#endif
 
 /*
   Command Pre-Processor

--- a/utils/tsscryptoh.c
+++ b/utils/tsscryptoh.c
@@ -453,6 +453,12 @@ TPM_RC TSS_RSA_padding_add_PKCS1_OAEP(unsigned char *em, uint32_t emLen,
     unsigned char *seedMask = NULL;		/* compiler false positive */
     unsigned char *maskedSeed;
 
+#ifdef TPM_TSS_NODEPRECATEDALGS
+    if (halg == TPM_ALG_SHA1) {
+        rc = TSS_RC_BAD_HASH_ALGORITHM;
+    }
+#endif
+
     uint16_t hlen = TSS_GetDigestSize(halg);
     em[0] = 0x00;	/* firsr byte is 0x00 per the standard */
     /* 1.a. If the length of L is greater than the input limitation for */

--- a/utils/verifysignature.c
+++ b/utils/verifysignature.c
@@ -484,5 +484,7 @@ static void printUsage(void)
     printf("\t01\tcontinue\n");
     printf("\t20\tcommand decrypt\n");
     printf("\t80\taudit\n");
+    printf("\n");
+    printf("Depending on the build configuration, some hash algorithms may not be available.\n");
     exit(1);	
 }


### PR DESCRIPTION
Since the usage of SHA-1 is considered insecure, this merge request restricts its usage. The usage has been removed primarily in places where it was used to create a new object, but it was kept to access already existing ones to help with upgrade or where there was no alternative algorithm.